### PR TITLE
feat: 가성비 마커 UI 및 필터상태에 따른 렌더링 구현

### DIFF
--- a/src/components/MapComp/utils/updateMarkers.tsx
+++ b/src/components/MapComp/utils/updateMarkers.tsx
@@ -15,7 +15,8 @@ interface UpdateMarkersArgs {
 
 type GetFeaturesOnScreenArgs = Pick<UpdateMarkersArgs, 'map' | 'allFeatures' | 'filterId'>;
 
-interface UpdatePointMarkersArgs extends Pick<UpdateMarkersArgs, 'map' | 'pointMarkerList' | 'handleClickMarker'> {
+interface UpdatePointMarkersArgs
+  extends Pick<UpdateMarkersArgs, 'map' | 'filterId' | 'pointMarkerList' | 'handleClickMarker'> {
   pointsOnScreen: CustomGeoJSONFeatures[];
 }
 
@@ -33,7 +34,7 @@ export const updateMarkers = ({
 }: UpdateMarkersArgs) => {
   const { pointsOnScreen, clustersOnScreen } = getFeaturesOnScreen({ map, allFeatures, filterId });
 
-  updatePointMarkers({ map, pointMarkerList, pointsOnScreen, handleClickMarker });
+  updatePointMarkers({ map, filterId, pointMarkerList, pointsOnScreen, handleClickMarker });
   updateClusterMarkers({ map, filterId, clusterMarkerList, clustersOnScreen });
 };
 
@@ -61,7 +62,13 @@ const getFeaturesOnScreen = ({ map, allFeatures, filterId }: GetFeaturesOnScreen
   return { pointsOnScreen, clustersOnScreen };
 };
 
-const updatePointMarkers = ({ map, pointMarkerList, pointsOnScreen, handleClickMarker }: UpdatePointMarkersArgs) => {
+const updatePointMarkers = ({
+  map,
+  filterId,
+  pointMarkerList,
+  pointsOnScreen,
+  handleClickMarker,
+}: UpdatePointMarkersArgs) => {
   Object.entries(pointMarkerList).forEach((markerEntry) => {
     const [id, marker] = markerEntry as [string, Marker];
     marker.remove();
@@ -77,6 +84,7 @@ const updatePointMarkers = ({ map, pointMarkerList, pointsOnScreen, handleClickM
           <PointMarker
             handleClickMarker={handleClickMarker}
             feature={feature}
+            activeFilterId={filterId}
             image="https://hipspot.s3.ap-northeast-2.amazonaws.com/store/0.jpg"
             id={id}
           />

--- a/src/components/Marker/pointMarker.tsx
+++ b/src/components/Marker/pointMarker.tsx
@@ -2,32 +2,44 @@ import styled from '@emotion/styled';
 import { FilterId } from '@libs/types/filter';
 import { CustomGeoJSONFeatures } from '@libs/types/map';
 
-type MarkerProps = {
-  /**
-   * 클러스터링 된 장소의 개수
-   * @example 3
-   */
+type PointMarkerProps = {
   id: number;
   image: string;
   feature: CustomGeoJSONFeatures;
+  activeFilterId: FilterId;
   handleClickMarker: (id: number) => void;
 };
 
-export default function PointMarker({ handleClickMarker, feature, image, id }: MarkerProps) {
+export default function PointMarker({ handleClickMarker, feature, activeFilterId, image, id }: PointMarkerProps) {
   const { placeName, filterList } = feature.properties;
+
+  /* 임시 값 삽입, 가성비가격 데이터 추가 이후 수정할 것 */
+  const reasonablePrice = 2500;
+
   return (
     <Wrapper className="mapgl-marker-animation" id={`${id}`} onClick={() => handleClickMarker(id)}>
       {/* filterList에 맞게 랜더링해주는지 테스트하기 위한 tag 추후 삭제해주세요 */}
       <div>{filterList.map((filter) => FilterId[filter]).join(', ')}</div>
       <CafeName>{placeName}</CafeName>
       <MarkerWrapper>
-        <svg width="98" height="111" viewBox="0 0 98 111" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d={backgroundPath} fill="#D9D9D9" stroke="white" />
-        </svg>
+        {activeFilterId === FilterId.Reasonable ? (
+          <>
+            <svg width="87" height="52" viewBox="0 0 87 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d={reasonablePath} fill="white" stroke="#F2BE19" strokeWidth="1.4" />
+            </svg>
 
-        <MaskImageWrapper>
-          <MaskImage image={image} />
-        </MaskImageWrapper>
+            <ReasonablePrice>{`${reasonablePrice.toLocaleString('ko-KR')}~`}</ReasonablePrice>
+          </>
+        ) : (
+          <>
+            <svg width="98" height="111" viewBox="0 0 98 111" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d={backgroundPath} fill="#D9D9D9" stroke="white" />
+            </svg>
+            <MaskImageWrapper>
+              <MaskImage image={image} />
+            </MaskImageWrapper>
+          </>
+        )}
       </MarkerWrapper>
     </Wrapper>
   );
@@ -39,6 +51,9 @@ const clipPath =
 const backgroundPath =
   'M5 0.5C2.51472 0.5 0.5 2.51472 0.5 5V93C0.5 95.4853 2.51472 97.5 5 97.5H35.3459L47.9196 110.053C48.5164 110.649 49.4836 110.649 50.0803 110.053L62.6541 97.5H93C95.4853 97.5 97.5 95.4853 97.5 93V5C97.5 2.51472 95.4853 0.5 93 0.5H5Z';
 
+const reasonablePath =
+  'M31.3452 39.4833L31.1446 39.3H30.8729H4C2.1775 39.3 0.7 37.8225 0.7 36V4C0.7 2.1775 2.1775 0.7 4 0.7H83C84.8224 0.7 86.3 2.17751 86.3 4V36C86.3 37.8225 84.8224 39.3 83 39.3H57.1271H56.8554L56.6548 39.4833L44.2024 50.8665C44.0878 50.9713 43.9122 50.9713 43.7976 50.8665L31.3452 39.4833Z';
+
 const Wrapper = styled.div`
   box-sizing: border-box;
   background-size: cover;
@@ -46,7 +61,9 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
 `;
+
 const MarkerWrapper = styled.div`
+  position: relative;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 `;
 
@@ -80,4 +97,20 @@ const CafeName = styled.div`
   white-space: nowrap;
   text-shadow: 0 0.5px white, 0.5px 0px white, -0.5px 0px white, 0px -0.5px white, 1px 1px 1px 77;
   transform: translate(0, -100%);
+`;
+
+const ReasonablePrice = styled.div`
+  position: absolute;
+  top: 0%;
+
+  width: 100%;
+  height: 40px;
+  color: #0d0d0d;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 40px;
+  text-align: center;
 `;


### PR DESCRIPTION
## Motivation
close #44 
- 기존 포인트마커 컴포넌트 스타일들을  재사용하여 가성비마커 UI 제작했습니다.
- 가성비 필터 상태일 때 기존 마커 자리에 가격과 함께 렌더링 되도록 구현했습니다.

<br>

## Key Changes

- 가성비 필터일 때 포인트마커가 변경되었습니다.

### 스크린샷
![image](https://user-images.githubusercontent.com/69510981/217728881-ba276373-9d6c-4e30-b3d9-188a0d1e1b7b.png)

<br>

## To Reviewers

- 디자인대로 구현하지 않은 부분이 있는지 중점으로 보면서 검토해주세요
