### PR TITLE
Feat: 마커 깜빡이는 현상 제거 #28

### DIFF
--- a/src/components/MapComp/index.tsx
+++ b/src/components/MapComp/index.tsx
@@ -22,7 +22,7 @@ function MapComp({ handleClickMarker }: MapCompProps) {
   const mapRef = useRef<mapboxgl.Map>();
   const activeFilterIdRef = useRef(activeFilterId);
   const pointMarkerList: { [id in number | string]: Marker } = useMemo(() => ({}), []);
-  const clusterMarkerList: Marker[] = useMemo(() => [], []);
+  const clusterMarkerList: { [id in number | string]: Marker } = useMemo(() => ({}), []);
 
   const handleUpdateMarkers = () => {
     const map = mapRef.current;

--- a/src/components/MapComp/index.tsx
+++ b/src/components/MapComp/index.tsx
@@ -11,6 +11,7 @@ import { FeatureCollection } from 'geojson';
 import getEnumNumberValues from '@libs/utils/getEnumNumberValues';
 import { mapConfig } from './utils/mapConfig';
 import { updateMarkers } from './utils/updateMarkers';
+import removeAllMarkers from './utils/removeAllMarkers';
 
 type MapCompProps = {
   handleClickMarker: (id: number) => void;
@@ -26,9 +27,10 @@ function MapComp({ handleClickMarker }: MapCompProps) {
 
   const handleUpdateMarkers = () => {
     const map = mapRef.current;
+    if (!map) return;
+
     const filterId = activeFilterIdRef.current;
 
-    if (!map) return;
     updateMarkers({
       map,
       filterId,
@@ -85,6 +87,9 @@ function MapComp({ handleClickMarker }: MapCompProps) {
 
   useEffect(() => {
     activeFilterIdRef.current = activeFilterId;
+
+    removeAllMarkers({ pointMarkerList, clusterMarkerList });
+
     handleUpdateMarkers();
   }, [activeFilterId]);
 

--- a/src/components/MapComp/utils/removeAllMarkers.ts
+++ b/src/components/MapComp/utils/removeAllMarkers.ts
@@ -1,0 +1,22 @@
+import { Marker } from 'mapbox-gl';
+
+interface RemoveAllMarkersArgs {
+  pointMarkerList: { [id in number | string]: Marker };
+  clusterMarkerList: { [id in number | string]: Marker };
+}
+
+const removeAllMarkers = ({ pointMarkerList, clusterMarkerList }: RemoveAllMarkersArgs) => {
+  Object.entries(pointMarkerList).forEach((markerEntry) => {
+    const [id, marker] = markerEntry as [string, Marker];
+    marker.remove();
+    delete pointMarkerList[id];
+  });
+
+  Object.entries(clusterMarkerList).forEach((markerEntry) => {
+    const [id, marker] = markerEntry as [string, Marker];
+    marker.remove();
+    delete clusterMarkerList[id];
+  });
+};
+
+export default removeAllMarkers;

--- a/src/components/MapComp/utils/updateMarkers.tsx
+++ b/src/components/MapComp/utils/updateMarkers.tsx
@@ -32,7 +32,7 @@ export const updateMarkers = ({
   // update point markers
   pointsOnScreen.forEach((feature: CustomGeoJSONFeatures) => {
     const { id } = feature.properties;
-    if (pointMarkerList[id]) return;
+    if (Object.hasOwn(pointMarkerList, id)) return;
 
     try {
       const marker = renderEmotionElementToHtml({
@@ -66,7 +66,8 @@ export const updateMarkers = ({
   // update cluster markers
   clustersOnScreen.forEach((feature) => {
     const id = feature.properties?.cluster_id;
-    if (clusterMarkerList[id]) return;
+    if (Object.hasOwn(clusterMarkerList, id)) return;
+
     const count = feature.properties?.point_count;
     const geo = feature.geometry;
 


### PR DESCRIPTION
## Motivation

close #28 
- 마커 렌더링 로직을 기존 모든마커를 지우고 새 마커를 띄우는 대신 선택적으로 띄우거나 삭제되도록 바꿨습니다.
- 이를 통해 맵 이동 시 모든 마커들이 깜빡거리는 현상이 해결되었습니다.

<br>

## Key Changes
- 뷰포트 근처 Features를 얻을 때 중복제거를 위해 사용한 Set들(uniquePointIds, uniqueClusterIds)을 재사용하여 마커 업데이트 기준을 설정 했습니다.
- 분리해놨던 포인트, 클러스터 마커 업데이트 함수 로직을 다시 합쳤습니다.
- 예를들면 힙스팟 상태에서 가성비 마커가 남아있는 상황이 생기지 않도록 필터 변경시에는 모든 마커를 지우고 새로 생성하도록 로직을 추가했습니다.

### 스크린샷
Before 
![214595995-c15715e8-fab0-46f0-a69e-66ce24bc07b7](https://user-images.githubusercontent.com/69510981/217979410-362cf4ff-1ba4-42dd-918d-fa3cd8a0b81e.gif)

<br>

Now
![chrome-capture-2023-1-10](https://user-images.githubusercontent.com/69510981/217978403-27e1d4ac-4842-49e1-867b-1656e90dea0d.gif)

<br>

## To Reviewers

- 로직 오류 여부를 중점으로 보면서 검토해주세요
