### PR TITLE
Fix: 이미지 슬라이더 우측으로 넘어가지 않던 버그 수정

### DIFF
--- a/src/components/InfoWindow/Contents/ImageSlider/eventHandler/mouse.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/eventHandler/mouse.ts
@@ -3,7 +3,11 @@ import moveImageSlider from '@components/InfoWindow/view/moveImageSlider';
 import stopImageSlideTransition from '@components/InfoWindow/view/stopImageSlideTransition';
 import { CSSVAR_IMAGE_SLIDER_WIDTH } from '@constants/cssVar';
 import { DOMID_IMAGE_SLIDER } from '@constants/DOM';
-import { HandleImageSliderStartProps, HandleImageSlideMoveProps, HandleImageSliderEndProps } from '@libs/types/slider';
+import {
+  HandleImageSliderStartProps,
+  HandleImageSlideMoveProps,
+  HandleImageSliderEndProps,
+} from '@libs/types/imageSlider';
 import { calcImageIndex, calcImageListPosition, calcNumberClamp } from '@libs/utils/calc';
 import { MouseEventHandler } from 'react';
 import { IMAGE_SLIDER_PADDING } from '@constants/imageSlider';
@@ -19,7 +23,7 @@ export const handleMouseDown: (props: HandleImageSliderStartProps) => MouseEvent
     model.update({
       onHandling: true,
       x: e.clientX,
-      startX: e.clientX,
+      anchorX: e.clientX,
     });
   };
 
@@ -31,8 +35,8 @@ export const handleMouseMove: (props: HandleImageSlideMoveProps) => MouseEventHa
 
     if (model.onHandling) {
       const { left: prevLeft, x } = model;
-      const move = e.clientX - x;
-      const left = prevLeft + move;
+      const dx = e.clientX - x;
+      const left = prevLeft + dx;
 
       moveImageSlider({ left });
 
@@ -52,8 +56,8 @@ export const handleMouseUp: (props: HandleImageSliderEndProps) => MouseEventHand
       const r = document.getElementById(DOMID_IMAGE_SLIDER) as HTMLDivElement;
       const width = parseFloat(r.style.getPropertyValue(CSSVAR_IMAGE_SLIDER_WIDTH));
       const blockWidth = width + IMAGE_SLIDER_PADDING;
-      const { left, imageListLength, startX, index: prevIndex } = model;
-      const displacement = e.clientX - startX;
+      const { left, imageListLength, anchorX, index: prevIndex } = model;
+      const displacement = e.clientX - anchorX;
 
       const index =
         Math.abs(displacement) < blockWidth
@@ -66,7 +70,7 @@ export const handleMouseUp: (props: HandleImageSliderEndProps) => MouseEventHand
 
       model.update({
         x: 0,
-        startX: 0,
+        anchorX: 0,
         onHandling: false,
         left: leftCorrectionValue,
         index,

--- a/src/components/InfoWindow/Contents/ImageSlider/eventHandler/mouse.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/eventHandler/mouse.ts
@@ -6,53 +6,53 @@ import { DOMID_IMAGE_SLIDER } from '@constants/DOM';
 import { HandleImageSliderStartProps, HandleImageSlideMoveProps, HandleImageSliderEndProps } from '@libs/types/slider';
 import { calcImageIndex, calcImageListPosition, calcNumberClamp } from '@libs/utils/calc';
 import { MouseEventHandler } from 'react';
-import { reactRefUpdate } from '../../PopUpWindow/utils/reactRefUpdate';
+import { IMAGE_SLIDER_PADDING } from '@constants/imageSlider';
 
 export const handleMouseDown: (props: HandleImageSliderStartProps) => MouseEventHandler<HTMLElement> =
-  ({ imageSliderRef }) =>
+  ({ model }) =>
   (e) => {
     e.preventDefault();
     e.stopPropagation();
 
     stopImageSlideTransition();
 
-    reactRefUpdate({
-      ref: imageSliderRef,
-      update: { ...imageSliderRef.current, x: e.clientX, startX: e.clientX, onHandling: true },
+    model.update({
+      onHandling: true,
+      x: e.clientX,
+      startX: e.clientX,
     });
   };
 
 export const handleMouseMove: (props: HandleImageSlideMoveProps) => MouseEventHandler<HTMLElement> =
-  ({ imageSliderRef }) =>
+  ({ model }) =>
   (e) => {
     e.preventDefault();
     e.stopPropagation();
 
-    if (imageSliderRef.current && imageSliderRef.current.onHandling) {
-      const { left: prevLeft, x } = imageSliderRef.current;
+    if (model.onHandling) {
+      const { left: prevLeft, x } = model;
       const move = e.clientX - x;
       const left = prevLeft + move;
 
       moveImageSlider({ left });
 
-      reactRefUpdate({
-        ref: imageSliderRef,
-        update: { ...imageSliderRef.current, x: e.clientX, left },
+      model.update({
+        x: e.clientX,
+        left,
       });
     }
   };
 
 export const handleMouseUp: (props: HandleImageSliderEndProps) => MouseEventHandler<HTMLElement> =
-  ({ imageSliderRef, setImageIndex }) =>
+  ({ model, setImageIndex }) =>
   (e) => {
     e.preventDefault();
     e.stopPropagation();
-
-    if (imageSliderRef.current && imageSliderRef.current.onHandling) {
+    if (model.onHandling) {
       const r = document.getElementById(DOMID_IMAGE_SLIDER) as HTMLDivElement;
       const width = parseFloat(r.style.getPropertyValue(CSSVAR_IMAGE_SLIDER_WIDTH));
-      const blockWidth = width + 16;
-      const { left, imageListLength, startX, index: prevIndex } = imageSliderRef.current;
+      const blockWidth = width + IMAGE_SLIDER_PADDING;
+      const { left, imageListLength, startX, index: prevIndex } = model;
       const displacement = e.clientX - startX;
 
       const index =
@@ -64,9 +64,12 @@ export const handleMouseUp: (props: HandleImageSliderEndProps) => MouseEventHand
 
       slideImageSlider({ leftCorrectionValue });
 
-      reactRefUpdate({
-        ref: imageSliderRef,
-        update: { ...imageSliderRef.current, x: 0, startX: 0, onHandling: false, left: leftCorrectionValue, index },
+      model.update({
+        x: 0,
+        startX: 0,
+        onHandling: false,
+        left: leftCorrectionValue,
+        index,
       });
       setImageIndex(index);
     }

--- a/src/components/InfoWindow/Contents/ImageSlider/eventHandler/touch.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/eventHandler/touch.ts
@@ -6,42 +6,45 @@ import { HandleImageSliderStartProps, HandleImageSlideMoveProps, HandleImageSlid
 import { calcImageIndex, calcImageListPosition, calcNumberClamp } from '@libs/utils/calc';
 import { DOMID_IMAGE_SLIDER } from '@constants/DOM';
 import { TouchEventHandler } from 'react';
-import { reactRefUpdate } from '../../PopUpWindow/utils/reactRefUpdate';
+import { IMAGE_SLIDER_PADDING } from '@constants/imageSlider';
 
 export const handleTouchStart: (props: HandleImageSliderStartProps) => TouchEventHandler<HTMLElement> =
-  ({ imageSliderRef }) =>
+  ({ model }) =>
   (e) => {
     stopImageSlideTransition();
-    reactRefUpdate({
-      ref: imageSliderRef,
-      update: { ...imageSliderRef.current, x: e.touches[0].clientX, startX: e.touches[0].clientX, onHandling: true },
+
+    model.update({
+      onHandling: true,
+      x: e.touches[0].clientX,
+      startX: e.touches[0].clientX,
     });
   };
 
 export const handleTouchMove: (props: HandleImageSlideMoveProps) => TouchEventHandler<HTMLElement> =
-  ({ imageSliderRef }) =>
+  ({ model }) =>
   (e) => {
-    if (imageSliderRef.current && imageSliderRef.current.onHandling) {
+    if (model.onHandling) {
       e.preventDefault();
-      const { left: prevLeft, x } = imageSliderRef.current;
+      const { left: prevLeft, x } = model;
       const move = e.touches[0].clientX - x;
       const left = prevLeft + move;
       moveImageSlider({ left });
-      reactRefUpdate({
-        ref: imageSliderRef,
-        update: { ...imageSliderRef.current, x: e.touches[0].clientX, left },
+
+      model.update({
+        x: e.touches[0].clientX,
+        left,
       });
     }
   };
 
 export const handleTouchEnd: (props: HandleImageSliderEndProps) => TouchEventHandler<HTMLElement> =
-  ({ imageSliderRef, setImageIndex }) =>
+  ({ model, setImageIndex }) =>
   (e) => {
-    if (imageSliderRef.current && imageSliderRef.current.onHandling) {
+    if (model.onHandling) {
       const r = document.getElementById(DOMID_IMAGE_SLIDER) as HTMLDivElement;
       const width = parseFloat(r.style.getPropertyValue(CSSVAR_IMAGE_SLIDER_WIDTH));
-      const blockWidth = width + 16;
-      const { left, imageListLength, startX, index: prevIndex } = imageSliderRef.current;
+      const blockWidth = width + IMAGE_SLIDER_PADDING;
+      const { left, imageListLength, startX, index: prevIndex } = model;
       const displacement = e.changedTouches[0].clientX - startX;
 
       const index =
@@ -53,10 +56,14 @@ export const handleTouchEnd: (props: HandleImageSliderEndProps) => TouchEventHan
 
       slideImageSlider({ leftCorrectionValue });
 
-      reactRefUpdate({
-        ref: imageSliderRef,
-        update: { ...imageSliderRef.current, x: 0, startX: 0, onHandling: false, left: leftCorrectionValue, index },
+      model.update({
+        x: 0,
+        startX: 0,
+        onHandling: false,
+        left: leftCorrectionValue,
+        index,
       });
+
       setImageIndex(index);
     }
   };

--- a/src/components/InfoWindow/Contents/ImageSlider/eventHandler/touch.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/eventHandler/touch.ts
@@ -2,7 +2,11 @@ import slideImageSlider from '@components/InfoWindow/view/slideImageSlider';
 import moveImageSlider from '@components/InfoWindow/view/moveImageSlider';
 import stopImageSlideTransition from '@components/InfoWindow/view/stopImageSlideTransition';
 import { CSSVAR_IMAGE_SLIDER_WIDTH } from '@constants/cssVar';
-import { HandleImageSliderStartProps, HandleImageSlideMoveProps, HandleImageSliderEndProps } from '@libs/types/slider';
+import {
+  HandleImageSliderStartProps,
+  HandleImageSlideMoveProps,
+  HandleImageSliderEndProps,
+} from '@libs/types/imageSlider';
 import { calcImageIndex, calcImageListPosition, calcNumberClamp } from '@libs/utils/calc';
 import { DOMID_IMAGE_SLIDER } from '@constants/DOM';
 import { TouchEventHandler } from 'react';
@@ -16,7 +20,7 @@ export const handleTouchStart: (props: HandleImageSliderStartProps) => TouchEven
     model.update({
       onHandling: true,
       x: e.touches[0].clientX,
-      startX: e.touches[0].clientX,
+      anchorX: e.touches[0].clientX,
     });
   };
 
@@ -26,8 +30,8 @@ export const handleTouchMove: (props: HandleImageSlideMoveProps) => TouchEventHa
     if (model.onHandling) {
       e.preventDefault();
       const { left: prevLeft, x } = model;
-      const move = e.touches[0].clientX - x;
-      const left = prevLeft + move;
+      const dx = e.touches[0].clientX - x;
+      const left = prevLeft + dx;
       moveImageSlider({ left });
 
       model.update({
@@ -44,8 +48,8 @@ export const handleTouchEnd: (props: HandleImageSliderEndProps) => TouchEventHan
       const r = document.getElementById(DOMID_IMAGE_SLIDER) as HTMLDivElement;
       const width = parseFloat(r.style.getPropertyValue(CSSVAR_IMAGE_SLIDER_WIDTH));
       const blockWidth = width + IMAGE_SLIDER_PADDING;
-      const { left, imageListLength, startX, index: prevIndex } = model;
-      const displacement = e.changedTouches[0].clientX - startX;
+      const { left, imageListLength, anchorX, index: prevIndex } = model;
+      const displacement = e.changedTouches[0].clientX - anchorX;
 
       const index =
         Math.abs(displacement) < blockWidth
@@ -57,9 +61,9 @@ export const handleTouchEnd: (props: HandleImageSliderEndProps) => TouchEventHan
       slideImageSlider({ leftCorrectionValue });
 
       model.update({
-        x: 0,
-        startX: 0,
         onHandling: false,
+        x: 0,
+        anchorX: 0,
         left: leftCorrectionValue,
         index,
       });

--- a/src/components/InfoWindow/Contents/ImageSlider/index.tsx
+++ b/src/components/InfoWindow/Contents/ImageSlider/index.tsx
@@ -2,17 +2,10 @@ import modifyImageSliderHeight from '@components/InfoWindow/view/modifyImageSlid
 import modifyImageSliderWidth from '@components/InfoWindow/view/modifyImageSliderWidth';
 import moveImageSlider from '@components/InfoWindow/view/moveImageSlider';
 import stopImageSlideTransition from '@components/InfoWindow/view/stopImageSlideTransition';
-import {
-  CSSVAR_IMAGE_SLIDER_HEIGHT,
-  CSSVAR_IMAGE_SLIDER_TRANSITION_DURATION,
-  CSSVAR_IMAGE_SLIDER_WIDTH,
-  CSSVAR_IMAGE_TRANSLATE,
-} from '@constants/cssVar';
 import { DOMID_IMAGE_SLIDER, DOMID_IMAGE_SLIDER_CONTAINER, DOMTargetList } from '@constants/DOM';
 import { EVENT_SLIDE_UP_WINDOW } from '@constants/event';
 import { popUpHeights } from '@constants/popUpHeights';
 import { imageSliderHeightTween, imageSliderWidthTween } from '@constants/Tween';
-import styled from '@emotion/styled';
 import { calcImageListPosition } from '@libs/utils/calc';
 import { createCustomEvent } from '@libs/utils/customEvent';
 import { useEffect, useState } from 'react';
@@ -21,7 +14,8 @@ import { handleMouseDown, handleMouseMove, handleMouseUp } from './eventHandler/
 import { handleSlidePopUpWindowForImageSlide } from './eventHandler/slideUpWindow';
 import { handleTouchEnd, handleTouchMove, handleTouchStart } from './eventHandler/touch';
 import usePopUpWindowLayoutControll from '../PopUpWindow/Contents/Layout/usePopUpWindowLayoutControll';
-import { ImageSliderModel } from './model';
+import ImageSliderModel from './model';
+import * as S from './style';
 
 interface SlideProps {
   wrapperId: string;
@@ -39,28 +33,43 @@ function ImageSlider({ wrapperId, imageList }: SlideProps) {
 
   const { max, min } = imageSliderWidthTween;
 
+  /**
+   * touch, mouse event handler
+   */
   const onMouseDownCapture = handleMouseDown({ model });
   const onMouseMoveCapture = handleMouseMove({ model });
   const onMouseUpCapture = handleMouseUp({ model, setImageIndex });
   const onTouchStartCapture = handleTouchStart({ model });
   const onTouchMoveCapture = handleTouchMove({ model }) as unknown as (e: TouchEvent) => void;
   const onTouchEndCapture = handleTouchEnd({ model, setImageIndex });
-
   const onSlidePopUpWindow = handleSlidePopUpWindowForImageSlide({ popUpHeights });
 
+  // touchMoveEvent는 preventDefault를 위해 passive로 등록,
   useEffect(() => {
-    model.update({
-      onHandling: false,
-      x: 0,
-      startX: 0,
-      imageListLength: imageList.length,
-      left: 0,
-      index: 0,
-    });
+    const wrapper = document.getElementById(wrapperId);
+    const container = document.getElementById(DOMID_IMAGE_SLIDER_CONTAINER);
+    if (wrapper && container) {
+      container.addEventListener('touchmove', onTouchMoveCapture, { passive: false });
+      wrapper.addEventListener(EVENT_SLIDE_UP_WINDOW, onSlidePopUpWindow);
+    }
+    return () => {
+      container?.removeEventListener('touchmove', onTouchMoveCapture, false);
+      wrapper?.removeEventListener(EVENT_SLIDE_UP_WINDOW, onSlidePopUpWindow);
+    };
+  }, []);
+
+  /**
+   * 이미지 슬라이더 초기화, model 초기화 및 imageList 맨 왼쪽으로 이동
+   */
+  useEffect(() => {
+    model.init(imageList.length);
     stopImageSlideTransition();
     moveImageSlider({ left: 0 });
   }, [imageList]);
 
+  /**
+   * 이미지 슬라이더 엘리먼트 DOMTargetList에 캐싱
+   */
   useEffect(() => {
     const wrapper = document.getElementById(wrapperId);
     const container = document.getElementById(DOMID_IMAGE_SLIDER_CONTAINER);
@@ -68,6 +77,9 @@ function ImageSlider({ wrapperId, imageList }: SlideProps) {
     DOMTargetList[DOMID_IMAGE_SLIDER_CONTAINER] = container;
   }, []);
 
+  /**
+   * SLIDE_UP_WINDOW 이벤트 리스너 등록
+   */
   useEffect(() => {
     const slideEvent = createCustomEvent(EVENT_SLIDE_UP_WINDOW, {
       currentTop: tabState.top,
@@ -95,25 +107,12 @@ function ImageSlider({ wrapperId, imageList }: SlideProps) {
 
     stopImageSlideTransition();
     moveImageSlider({ left: leftCorrectionValue });
-    model.update({ x: 0, startX: 0, onHandling: false, left: leftCorrectionValue });
+    model.update({ x: 0, anchorX: 0, onHandling: false, left: leftCorrectionValue });
   }, [tabState]);
 
-  useEffect(() => {
-    const wrapper = document.getElementById(wrapperId);
-    const container = document.getElementById(DOMID_IMAGE_SLIDER_CONTAINER);
-    if (wrapper && container) {
-      container.addEventListener('touchmove', onTouchMoveCapture, { passive: false });
-      wrapper.addEventListener(EVENT_SLIDE_UP_WINDOW, onSlidePopUpWindow);
-    }
-    return () => {
-      container?.removeEventListener('touchmove', onTouchMoveCapture, false);
-      wrapper?.removeEventListener(EVENT_SLIDE_UP_WINDOW, onSlidePopUpWindow);
-    };
-  }, []);
-
   return (
-    <SliderWrapper>
-      <SlideContainer
+    <S.SliderWrapper>
+      <S.SlideContainer
         id={DOMID_IMAGE_SLIDER_CONTAINER}
         onMouseMoveCapture={onMouseMoveCapture}
         onMouseDownCapture={onMouseDownCapture}
@@ -123,7 +122,7 @@ function ImageSlider({ wrapperId, imageList }: SlideProps) {
         onTouchEndCapture={onTouchEndCapture}
       >
         {imageList.map((imageSrc, i) => (
-          <Image
+          <S.Image
             src={imageSrc}
             key={imageSrc}
             selected={i === imageIndex}
@@ -137,8 +136,8 @@ function ImageSlider({ wrapperId, imageList }: SlideProps) {
             }}
           />
         ))}
-      </SlideContainer>
-    </SliderWrapper>
+      </S.SlideContainer>
+    </S.SliderWrapper>
   );
 }
 
@@ -146,58 +145,10 @@ export default ImageSlider;
 
 export function CustomImageSliderSkeleton() {
   return (
-    <SkeltonWrapper>
+    <S.SkeltonWrapper>
       <div>
         <Loading color="pink" />
       </div>
-    </SkeltonWrapper>
+    </S.SkeltonWrapper>
   );
 }
-
-const SkeltonWrapper = styled.div`
-  padding: 0px 16px;
-  width: 100%;
-  height: var(${CSSVAR_IMAGE_SLIDER_HEIGHT}, 343);
-  & > div {
-    background-color: #d6d6d6;
-    width: 100%;
-    height: 100%;
-    border-radius: 8px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-`;
-
-const SliderWrapper = styled.div`
-  overflow: hidden;
-`;
-
-const SlideContainer = styled.div`
-  height: var(${CSSVAR_IMAGE_SLIDER_HEIGHT});
-  padding-left: 16px;
-  width: 1000vw;
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 16px;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-
-  transform: translate3d(var(${CSSVAR_IMAGE_TRANSLATE}), 0px, 0px);
-  transition: ease-in-out var(${CSSVAR_IMAGE_SLIDER_TRANSITION_DURATION});
-`;
-
-const Image = styled.img<{ selected: boolean; initSize: { height: number; width: number } }>`
-  border-radius: 8px;
-  flex: 0 0 auto;
-  height: ${(props) => (props.selected ? `var(${CSSVAR_IMAGE_SLIDER_HEIGHT})` : `${props.initSize.height}px`)};
-  width: ${(props) => (props.selected ? `var(${CSSVAR_IMAGE_SLIDER_WIDTH})` : `${props.initSize.width}px`)};
-  object-fit: cover;
-  object-position: center;
-  position: relative;
-  z-index: ${(props) => (props.selected ? 11 : 1)};
-`;

--- a/src/components/InfoWindow/Contents/ImageSlider/model.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/model.ts
@@ -1,7 +1,7 @@
 interface IImageSliderModel {
   onHandling: boolean;
   x: number;
-  startX: number;
+  anchorX: number;
   index: number;
   left: number;
   imageListLength: number;
@@ -9,12 +9,12 @@ interface IImageSliderModel {
   update<T extends keyof IImageSliderModel>(key: T, value: this[T]): void;
 }
 
-export class ImageSliderModel implements IImageSliderModel {
+class ImageSliderModel implements IImageSliderModel {
   onHandling: boolean;
 
   x: number;
 
-  startX: number;
+  anchorX: number;
 
   index: number;
 
@@ -22,13 +22,30 @@ export class ImageSliderModel implements IImageSliderModel {
 
   imageListLength: number;
 
+  /**
+   * @param onHandling 슬라이더를 움직이고 있는지 여부
+   * @param x 실시간으로 움직이는 슬라이더의 x 좌표, 터치무브 이벤트마다의 이동거리를 계산하기 위해 사용
+   * @param anchorX 터치 시작 시 x 좌표
+   * @param index 이미지 슬라이더 가장 좌측에 보이는 사진의 인덱스값
+   * @param left 이미지 슬라이더를 실제로 transfrom 해주는값
+   * @param imageListLength 이미지 리스트 배열의 length, 이미지의 갯수를 의미
+   */
   constructor() {
     this.onHandling = false;
     this.x = 0;
-    this.startX = 0;
+    this.anchorX = 0;
     this.index = 0;
     this.left = 0;
     this.imageListLength = 0;
+  }
+
+  init(imageListLength: number) {
+    this.onHandling = false;
+    this.x = 0;
+    this.anchorX = 0;
+    this.index = 0;
+    this.left = 0;
+    this.imageListLength = imageListLength;
   }
 
   update<T extends keyof IImageSliderModel>(...params: [Partial<IImageSliderModel>] | [T, this[T]]): void {
@@ -55,7 +72,7 @@ export class ImageSliderModel implements IImageSliderModel {
   validate<T extends keyof IImageSliderModel>(key: T, value: this[T]): boolean {
     switch (key) {
       case 'x':
-      case 'startX':
+      case 'anchorX':
       case 'index':
       case 'left':
         if (Number.isNaN(value)) return false;
@@ -73,3 +90,5 @@ export class ImageSliderModel implements IImageSliderModel {
     return true;
   }
 }
+
+export default ImageSliderModel;

--- a/src/components/InfoWindow/Contents/ImageSlider/model.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/model.ts
@@ -1,0 +1,75 @@
+interface IImageSliderModel {
+  onHandling: boolean;
+  x: number;
+  startX: number;
+  index: number;
+  left: number;
+  imageListLength: number;
+  update(partial: Partial<IImageSliderModel>): void;
+  update<T extends keyof IImageSliderModel>(key: T, value: this[T]): void;
+}
+
+export class ImageSliderModel implements IImageSliderModel {
+  onHandling: boolean;
+
+  x: number;
+
+  startX: number;
+
+  index: number;
+
+  left: number;
+
+  imageListLength: number;
+
+  constructor() {
+    this.onHandling = false;
+    this.x = 0;
+    this.startX = 0;
+    this.index = 0;
+    this.left = 0;
+    this.imageListLength = 0;
+  }
+
+  update<T extends keyof IImageSliderModel>(...params: [Partial<IImageSliderModel>] | [T, this[T]]): void {
+    if (params.length === 1 || typeof params[0] === 'object') {
+      const partial = params[0];
+      Object.entries(partial).forEach((entries) => {
+        const [key, value] = entries as [T, this[T]];
+        if (!this.validate(key, value)) return;
+        this.update(key, value);
+      });
+
+      return;
+    }
+
+    if (params.length === 2) {
+      const [key, value] = params;
+      if (this.validate(key, value)) {
+        this[key] = value;
+      }
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  validate<T extends keyof IImageSliderModel>(key: T, value: this[T]): boolean {
+    switch (key) {
+      case 'x':
+      case 'startX':
+      case 'index':
+      case 'left':
+        if (Number.isNaN(value)) return false;
+        break;
+      case 'imageListLength':
+        if (Number.isNaN(value) || typeof value !== 'number') return false; // 타입 검사 추가
+        if (value <= 0) return false;
+        break;
+      case 'onHandling':
+        if (typeof value !== 'boolean') return false;
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+}

--- a/src/components/InfoWindow/Contents/ImageSlider/style.ts
+++ b/src/components/InfoWindow/Contents/ImageSlider/style.ts
@@ -1,0 +1,55 @@
+import {
+  CSSVAR_IMAGE_SLIDER_HEIGHT,
+  CSSVAR_IMAGE_SLIDER_TRANSITION_DURATION,
+  CSSVAR_IMAGE_SLIDER_WIDTH,
+  CSSVAR_IMAGE_TRANSLATE,
+} from '@constants/cssVar';
+import styled from '@emotion/styled';
+
+export const SkeltonWrapper = styled.div`
+  padding: 0px 16px;
+  width: 100%;
+  height: var(${CSSVAR_IMAGE_SLIDER_HEIGHT}, 343);
+  & > div {
+    background-color: #d6d6d6;
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+export const SliderWrapper = styled.div`
+  overflow: hidden;
+`;
+
+export const SlideContainer = styled.div`
+  height: var(${CSSVAR_IMAGE_SLIDER_HEIGHT});
+  padding-left: 16px;
+  width: 1000vw;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 16px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  transform: translate3d(var(${CSSVAR_IMAGE_TRANSLATE}), 0px, 0px);
+  transition: ease-in-out var(${CSSVAR_IMAGE_SLIDER_TRANSITION_DURATION});
+`;
+
+export const Image = styled.img<{ selected: boolean; initSize: { height: number; width: number } }>`
+  border-radius: 8px;
+  flex: 0 0 auto;
+  height: ${(props) => (props.selected ? `var(${CSSVAR_IMAGE_SLIDER_HEIGHT})` : `${props.initSize.height}px`)};
+  width: ${(props) => (props.selected ? `var(${CSSVAR_IMAGE_SLIDER_WIDTH})` : `${props.initSize.width}px`)};
+  object-fit: cover;
+  object-position: center;
+  position: relative;
+  z-index: ${(props) => (props.selected ? 11 : 1)};
+`;

--- a/src/constants/imageSlider.ts
+++ b/src/constants/imageSlider.ts
@@ -1,0 +1,1 @@
+export const IMAGE_SLIDER_PADDING = 16;

--- a/src/libs/types/imageSlider.ts
+++ b/src/libs/types/imageSlider.ts
@@ -1,4 +1,4 @@
-import { ImageSliderModel } from '@components/InfoWindow/Contents/ImageSlider/model';
+import ImageSliderModel from '@components/InfoWindow/Contents/ImageSlider/model';
 
 export interface HandleImageSliderStartProps {
   model: ImageSliderModel;

--- a/src/libs/types/slider.ts
+++ b/src/libs/types/slider.ts
@@ -1,23 +1,14 @@
-import { RefObject } from 'react';
-
-export interface ImageSliderRef {
-  onHandling: boolean;
-  x: number;
-  startX: number;
-  index: number;
-  left: number;
-  imageListLength: number;
-}
+import { ImageSliderModel } from '@components/InfoWindow/Contents/ImageSlider/model';
 
 export interface HandleImageSliderStartProps {
-  imageSliderRef: RefObject<ImageSliderRef>;
+  model: ImageSliderModel;
 }
 
 export interface HandleImageSlideMoveProps {
-  imageSliderRef: RefObject<ImageSliderRef>;
+  model: ImageSliderModel;
 }
 
 export interface HandleImageSliderEndProps {
-  imageSliderRef: RefObject<ImageSliderRef>;
+  model: ImageSliderModel;
   setImageIndex: React.Dispatch<React.SetStateAction<number>>;
 }


### PR DESCRIPTION
## 스크린샷

https://user-images.githubusercontent.com/66112027/235485004-771603b5-d39d-40c8-acfb-0977f7a53f5b.mov

https://user-images.githubusercontent.com/66112027/235485019-67e20675-3b33-46b3-bb21-d527e4481be6.mov


## Motivation

- #84  

### ref를 수정하지 않아 버그 발생
이미지 슬라이더 컴포넌트에 imageList 배열을 전달해주는데, 해당 배열 변화에도 imageSliderRef 내의 imageListLength가 변화하지 않아 버그가 발생했습니다

### useRef 대신 클래스로 인스턴스를 만들어 사용
팝업윈도우 개발중 비슷한 상황이 있었던것 같습니다. 상태가 변경되어도 useRef는 변하지 않는다는 점, hooks 호출시마다 각각의 ref가 생성된다는점?(useRef에 대한 이해가 좀 더 필요할것 같은데, 현재는 추측상 그렇습니다) 과 같은 이슈가 있어서, 팝업윈도우를 개발했을 때처럼 인터랙션 동작에 필요한 객체를 만들고, 이 객체를 참조하게 함으로써 핸들러 동작에도 ref가 업데이트 되지 않았던 이슈를 해결했습니다.


<br>


## To Reviewers
- ImageSlider 컴포넌트를 집중적으로 봐주세요
- ImageSlider 컴포넌트에 useEffect가 덕지덕지 붙어있어서 리팩토링을 함 하면 좋을거같은데 다음 이슈에 추가해서 진행해보겠습니다~
