### PR TITLE
Style: 지도 이미지 변경 및 포인터마커 썸네일 Url 변경

### DIFF
--- a/src/components/MapComp/hooks/useMap.ts
+++ b/src/components/MapComp/hooks/useMap.ts
@@ -8,7 +8,7 @@ mapboxgl.workerClass = require('worker-loader!mapbox-gl/dist/mapbox-gl-csp-worke
 
 export const mapConfig: MapboxOptions = {
   container: 'map',
-  style: 'mapbox://styles/mapbox/streets-v11?optimize=true',
+  style: 'mapbox://styles/sangjun/clgwfbvxr003s01r88wfc14jo',
   center: [127.0770389, 37.6257614],
   zoom: 17,
   maxZoom: 18,

--- a/src/components/MapComp/hooks/useMarkerUpdate.ts
+++ b/src/components/MapComp/hooks/useMarkerUpdate.ts
@@ -2,7 +2,6 @@ import ClusterMarker from '@components/Marker/clusterMarker';
 import PointMarker from '@components/Marker/pointMarker';
 import ReasonableMarker from '@components/Marker/ReasonableMarker';
 import FranchiseMarker from '@components/Marker/FranchiseMarker';
-import { S3_URL } from '@constants/s3Url';
 import { CustomGeoJSONFeatures, MarkerList } from '@libs/types/map';
 import { renderEmotionElementToHtml } from '@libs/utils/renderEmotionElementToHtml';
 import { activeFilterIdAtom } from '@states/clusterList';
@@ -35,7 +34,7 @@ function useMarkerUpdate() {
 
     // point markers
     pointFeaturesOnScreen.forEach((feature) => {
-      const { cafeId, cafeName, thumbNail } = feature.properties;
+      const { cafeId, cafeName } = feature.properties;
       if (Object.hasOwn(pointMarkerList, cafeId)) return;
       try {
         if (filterId === 2) {
@@ -59,7 +58,6 @@ function useMarkerUpdate() {
             elem: PointMarker({
               handleClickPointMarker: pointMarkerClickAction,
               feature,
-              image: `${S3_URL}/${cafeId}/store/${thumbNail}`,
             }),
             cssDataKey: 'marker',
           });
@@ -159,7 +157,7 @@ function useMarkerUpdate() {
     const map = mapRef.current;
     if (!map) return;
 
-    const { cafeId, cafeName, thumbNail } = feature.properties;
+    const { cafeName } = feature.properties;
 
     try {
       if (filterId === 2) {
@@ -186,7 +184,6 @@ function useMarkerUpdate() {
           elem: PointMarker({
             handleClickPointMarker: pointMarkerClickAction,
             feature,
-            image: `${S3_URL}/${cafeId}/store/${thumbNail}`,
           }),
           cssDataKey: 'marker',
         });

--- a/src/components/Marker/clusterMarker.tsx
+++ b/src/components/Marker/clusterMarker.tsx
@@ -22,40 +22,44 @@ export default function ClusterMarker({ count, filterId, handleClickClusterMarke
   const clusterColors = filteredClusterColor[filterId];
 
   return (
-    <Wrapper
-      onClick={onClick}
-      wrapperColor={clusterColors.wrapperColor}
-      wrapperBoxShadowColor={clusterColors.wrapperBoxShadowColor}
-    >
+    <ClusterMarkerWrapper>
+      <OuterCircle
+        onClick={onClick}
+        OuterCircleColor={clusterColors.OuterCircleColor}
+        OuterCircleBoxShadowColor={clusterColors.OuterCircleBoxShadowColor}
+      />
       <InnerCircle
         innerCircleColor={clusterColors.innerCircleColor}
         innerCircleBoxShadowColorX={clusterColors.innerCircleBoxShadowColorX}
         innerCircleBoxShadowColorY={clusterColors.innerCircleBoxShadowColorY}
+      />
+      <ClusterPointNumberText>+{count}</ClusterPointNumberText>
+      <ClusterPointNumberShadow
+        textShadowColorX={clusterColors.textShadowColorX}
+        textShadowColorY={clusterColors.textShadowColorY}
       >
-        <ClusterPointNumberText>+{count}</ClusterPointNumberText>
-        <ClusterPointNumberShadow
-          textShadowColorX={clusterColors.textShadowColorX}
-          textShadowColorY={clusterColors.textShadowColorY}
-        >
-          +{count}
-        </ClusterPointNumberShadow>
-      </InnerCircle>
-    </Wrapper>
+        +{count}
+      </ClusterPointNumberShadow>
+    </ClusterMarkerWrapper>
   );
 }
-
-const Wrapper = styled.div<{ wrapperColor: string; wrapperBoxShadowColor: string }>`
-  width: 64px;
-  height: 64px;
-  background-color: ${(props) => props.wrapperColor};
-  border: 1.6px solid ${(props) => props.wrapperColor};
-  border-radius: 50%;
-  box-shadow: inset 0px 0px 8px ${(props) => props.wrapperBoxShadowColor};
-  filter: drop-shadow(0px 12px 24px rgba(0, 0, 0, 0.16));
-
+const ClusterMarkerWrapper = styled.div`
+  width: 52px;
+  height: 52px;
   display: flex;
   justify-content: center;
   align-items: center;
+  filter: drop-shadow(0px 12px 24px rgba(0, 0, 0, 0.16));
+`;
+
+const OuterCircle = styled.div<{ OuterCircleColor: string; OuterCircleBoxShadowColor: string }>`
+  position: absolute;
+  width: 52px;
+  height: 52px;
+  background-color: ${(props) => props.OuterCircleColor};
+  border: 1.6px solid ${(props) => props.OuterCircleColor};
+  border-radius: 50%;
+  box-shadow: inset 0px 0px 10px ${(props) => props.OuterCircleBoxShadowColor};
 `;
 
 const InnerCircle = styled.div<{
@@ -63,15 +67,16 @@ const InnerCircle = styled.div<{
   innerCircleBoxShadowColorX: string;
   innerCircleBoxShadowColorY: string;
 }>`
-  position: relative;
-  width: 53px;
-  height: 53px;
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  box-sizing: border-box;
   background-color: ${(props) => props.innerCircleColor};
   border-radius: 50%;
   box-shadow: 1px -1px 2px ${(props) => props.innerCircleBoxShadowColorX},
     -1px 1px 2px ${(props) => props.innerCircleBoxShadowColorY};
-
   display: flex;
+  opacity: 0.7;
   justify-content: center;
   align-items: center;
 `;
@@ -107,17 +112,17 @@ const ClusterPointNumberShadow = styled.div<{
 
 const filteredClusterColor = [
   {
-    wrapperColor: '#F889FA',
-    wrapperBoxShadowColor: 'rgba(123, 9, 112, 0.35)',
+    OuterCircleColor: '#F889FA',
+    OuterCircleBoxShadowColor: 'rgba(123, 9, 112, 0.35)',
     innerCircleColor: '#F699ED',
     innerCircleBoxShadowColorX: 'rgba(250, 202, 251, 0.9)',
-    innerCircleBoxShadowColorY: 'rgba(0, 0, 0, 0.12)',
+    innerCircleBoxShadowColorY: 'rgba(23, 10, 0, 0.12)',
     textShadowColorX: 'rgba(71, 3, 68, 0.4)',
     textShadowColorY: 'rgba(245, 165, 237, 0.8)',
   },
   {
-    wrapperColor: '#32D186',
-    wrapperBoxShadowColor: '#3D785C',
+    OuterCircleColor: '#32D186',
+    OuterCircleBoxShadowColor: '#3D785C',
     innerCircleColor: '#32D186',
     innerCircleBoxShadowColorX: 'rgba(123, 225, 170, 0.9)',
     innerCircleBoxShadowColorY: 'rgba(2, 30, 25, 0.12)',
@@ -125,8 +130,8 @@ const filteredClusterColor = [
     textShadowColorY: '#48E39A',
   },
   {
-    wrapperColor: '#F2BE19',
-    wrapperBoxShadowColor: 'rgba(133, 50, 3, 0.2)',
+    OuterCircleColor: '#F2BE19',
+    OuterCircleBoxShadowColor: 'rgba(133, 50, 3, 0.2)',
     innerCircleColor: '#F2BE19',
     innerCircleBoxShadowColorX: 'rgba(249, 199, 125, 0.9)',
     innerCircleBoxShadowColorY: 'rgba(23, 10, 0, 0.12)',
@@ -134,8 +139,8 @@ const filteredClusterColor = [
     textShadowColorY: '#FDC999',
   },
   {
-    wrapperColor: '#BF8D69',
-    wrapperBoxShadowColor: 'rgba(133, 50, 3, 0.35)',
+    OuterCircleColor: '#BF8D69',
+    OuterCircleBoxShadowColor: 'rgba(133, 50, 3, 0.35)',
     innerCircleColor: '#BF8D69',
     innerCircleBoxShadowColorX: 'rgba(223, 171, 123, 0.9)',
     innerCircleBoxShadowColorY: 'rgba(23, 10, 0, 0.12)',
@@ -143,8 +148,8 @@ const filteredClusterColor = [
     textShadowColorY: '#FDC999',
   },
   {
-    wrapperColor: '#418DFF',
-    wrapperBoxShadowColor: 'rgba(3, 55, 133, 0.35)',
+    OuterCircleColor: '#418DFF',
+    OuterCircleBoxShadowColor: 'rgba(3, 55, 133, 0.35)',
     innerCircleColor: '#418DFF',
     innerCircleBoxShadowColorX: 'rgba(122, 170, 242, 0.9)',
     innerCircleBoxShadowColorY: 'rgba(23, 10, 0, 0.12)',
@@ -152,8 +157,8 @@ const filteredClusterColor = [
     textShadowColorY: '#90B8F2',
   },
   {
-    wrapperColor: '#B46FEA',
-    wrapperBoxShadowColor: 'rgba(76, 3, 133, 0.35)',
+    OuterCircleColor: '#B46FEA',
+    OuterCircleBoxShadowColor: 'rgba(76, 3, 133, 0.35)',
     innerCircleColor: '#B46FEA',
     innerCircleBoxShadowColorX: '#C6A1F7',
     innerCircleBoxShadowColorY: 'rgba(23, 10, 0, 0.12)',

--- a/src/components/Marker/pointMarker.tsx
+++ b/src/components/Marker/pointMarker.tsx
@@ -14,7 +14,7 @@ export default function PointMarker({ handleClickPointMarker, feature, image }: 
     <Wrapper className="mapgl-marker-animation" id={`${cafeId}`} onClick={() => handleClickPointMarker(cafeId)}>
       <CafeName>{cafeName}</CafeName>
       <MarkerWrapper>
-        <svg width="98" height="111" viewBox="0 0 98 111" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="78" height="86" viewBox="0 0 78 86" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d={backgroundPath} fill="#D9D9D9" stroke="white" />
         </svg>
         <MaskImageWrapper>
@@ -26,10 +26,10 @@ export default function PointMarker({ handleClickPointMarker, feature, image }: 
 }
 
 const clipPath =
-  'M4 0C1.79086 0 0 1.79086 0 4V92C0 94.2091 1.79086 96 4 96H34.5528L47.2729 108.699C47.6745 109.1 48.3255 109.1 48.7271 108.699L61.4472 96H92C94.2091 96 96 94.2091 96 92V4C96 1.79086 94.2091 0 92 0H4Z';
+  'M4 0C1.79086 0 0 1.79086 0 4V72C0 74.2091 1.79086 76 4 76H29.112L37.4183 83.7745C37.7396 84.0752 38.2604 84.0752 38.5817 83.7745L46.888 76H72C74.2091 76 76 74.2091 76 72V4C76 1.79086 74.2091 0 72 0H4Z';
 
 const backgroundPath =
-  'M5 0.5C2.51472 0.5 0.5 2.51472 0.5 5V93C0.5 95.4853 2.51472 97.5 5 97.5H35.3459L47.9196 110.053C48.5164 110.649 49.4836 110.649 50.0803 110.053L62.6541 97.5H93C95.4853 97.5 97.5 95.4853 97.5 93V5C97.5 2.51472 95.4853 0.5 93 0.5H5Z';
+  'M5 0C2.23858 0 0 2.23857 0 5V73C0 75.7614 2.23857 78 5 78H29.717L37.735 85.5046C38.4407 86.1651 39.5593 86.1651 40.265 85.5046L48.283 78H73C75.7614 78 78 75.7614 78 73V5C78 2.23858 75.7614 0 73 0H5Z';
 
 const Wrapper = styled.div`
   box-sizing: border-box;
@@ -48,17 +48,16 @@ const MaskImageWrapper = styled.div`
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 111px;
+  height: 84px;
   overflow: hidden;
   clip-path: path('${clipPath}');
 `;
 const MaskImage = styled.div<{ image: string }>`
-  width: 110px;
-  height: 120px;
+  width: 76px;
+  height: 84px;
   background: url('${(props) => props.image}');
   background-size: cover;
   background-position: center;
-  transform: translate(-10px, -10px);
 `;
 
 const CafeName = styled.div`

--- a/src/components/Marker/pointMarker.tsx
+++ b/src/components/Marker/pointMarker.tsx
@@ -1,13 +1,13 @@
+import { S3_URL } from '@constants/s3Url';
 import styled from '@emotion/styled';
 import { CustomGeoJSONFeatures } from '@libs/types/map';
 
 export type PointMarkerProps = {
-  image: string;
   feature: CustomGeoJSONFeatures;
   handleClickPointMarker: (id: number) => void;
 };
 
-export default function PointMarker({ handleClickPointMarker, feature, image }: PointMarkerProps) {
+export default function PointMarker({ handleClickPointMarker, feature }: PointMarkerProps) {
   const { cafeId, cafeName } = feature.properties;
 
   return (
@@ -18,7 +18,7 @@ export default function PointMarker({ handleClickPointMarker, feature, image }: 
           <path d={backgroundPath} fill="#D9D9D9" stroke="white" />
         </svg>
         <MaskImageWrapper>
-          <MaskImage image={image} />
+          <MaskImage image={`${S3_URL}/${cafeId}/thumbNail.jpg`} />
         </MaskImageWrapper>
       </MarkerWrapper>
     </Wrapper>

--- a/src/components/Marker/pointMarker.tsx
+++ b/src/components/Marker/pointMarker.tsx
@@ -71,7 +71,7 @@ const CafeName = styled.div`
   line-height: 24px;
 
   white-space: nowrap;
-  text-shadow: -2px -2px 0 #fff, 0 -2px 0 #fff, 2px -2px 0 #fff, 2px 0 0 #fff, 2px 2px 0 #fff, 0 2px 0 #fff,
-    -2px 2px 0 #fff, -2px 0 0 #fff;
+  text-shadow: -1.5px -1.5px 0 #fff, 0 -1.5px 0 #fff, 1.5px -1.5px 0 #fff, 1.5px 0 0 #fff, 1.5px 1.5px 0 #fff,
+    0 1.5px 0 #fff, -1.5px 1.5px 0 #fff, -1.5px 0 0 #fff;
   transform: translate(0, -100%);
 `;


### PR DESCRIPTION
# 스크린샷
### 지도 이미지 변경
<img width="559" alt="스크린샷 2023-05-04 오전 12 29 44" src="https://user-images.githubusercontent.com/66112027/235971356-a98e80ec-3937-479b-a00a-b511254708bb.png">

> 변경후 / 변경전

### 썸네일 크기 변경
* 변경전 퍼포먼스
<img width="411" alt="스크린샷 2023-05-04 오전 12 39 12" src="https://user-images.githubusercontent.com/66112027/235972104-5b127e90-a992-4f29-86b5-f60ee45798be.png">

* 변경후 퍼포먼스
<img width="432" alt="스크린샷 2023-05-04 오전 12 37 21" src="https://user-images.githubusercontent.com/66112027/235972123-5b75643a-7139-4c5b-80c8-7dbec5f39cc8.png">

> 약 500 x 400 크기의 이미지에서 200x200 크기로 변경한 결과 
> 랜더링, 페인트 부분 성능이 개선되었습니다. 

## Motivation

하지만 진짜 문제는 지도가 3d 효과를 주며 이동할 때 버벅거리는 문제가 발생한다는 점인데, 지도에 마커 띄우는 랜더링 로직을 한번 더 개선해보고 안되면 아무래도 맵 자체에서 기본적으로 사용하는 리소스때문에 그러는게 아닐까 싶습니다 최대한 개선해봐요~

