### PR TITLE
Feat: 플러터 온보딩 필터 요청 및 적용 #108

### DIFF
--- a/src/components/Filtering/index.tsx
+++ b/src/components/Filtering/index.tsx
@@ -2,8 +2,15 @@ import styled from '@emotion/styled';
 import filterDataList from '@constants/filterDataList';
 import { FilterId } from '@libs/types/filter';
 import FilterItem from './FilterItem';
+import { useEffect } from 'react';
+import messageToFlutter from '@libs/webview/messageToFlutter';
+import { MessageToFlutterType } from '@constants/flutterCallback';
 
 export default function Filtering() {
+  useEffect(() => {
+    messageToFlutter(MessageToFlutterType.getOnboardingFilter, null);
+  }, []);
+
   return (
     <Wrapper>
       {Object.values(filterDataList).map((filter, index: FilterId) => (

--- a/src/constants/flutterCallback.ts
+++ b/src/constants/flutterCallback.ts
@@ -8,6 +8,7 @@ export enum FlutterCallback {
   setNotchHeight,
   setIsWebView,
   setFavoriteList,
+  setOnboardingFilter,
 }
 
 export enum MessageToFlutterType {
@@ -19,4 +20,5 @@ export enum MessageToFlutterType {
   removeFavorite = 'removeFavorite',
   getIsWebView = 'getIsWebView',
   getFavoriteList = 'getFavoriteList',
+  getOnboardingFilter = 'getOnboardingFilter',
 }

--- a/src/libs/webview/useFlutterMessageHandler.ts
+++ b/src/libs/webview/useFlutterMessageHandler.ts
@@ -8,12 +8,16 @@ import { notchHeightAtom } from '@states/header';
 import { isWebViewAtom } from '@states/isWebView';
 import { favoriteListAtom } from '@states/favoriteList';
 import { parseStringifiedArray } from '@libs/utils/parseStringifiedArray';
+import { activeFilterIdAtom } from '@states/clusterList';
+import { FilterId } from '@libs/types/filter';
+import getEnumNumberValues from '@libs/utils/getEnumNumberValues';
 
 export default function useFlutterMessageHandler() {
   const setAuth = useSetAuth();
   const setNotchHeightAtom = useSetRecoilState(notchHeightAtom);
   const setIsWebViewAtom = useSetRecoilState(isWebViewAtom);
   const setFavoriteList = useSetRecoilState(favoriteListAtom);
+  const setActiveFilterId = useSetRecoilState(activeFilterIdAtom);
 
   return ({ type, data }: Message) => {
     switch (FlutterCallback[type]) {
@@ -29,6 +33,9 @@ export default function useFlutterMessageHandler() {
         return setIsWebViewAtom(true);
       case FlutterCallback.setFavoriteList:
         return setFavoriteList(parseStringifiedArray(data));
+      case FlutterCallback.setOnboardingFilter:
+        if (!getEnumNumberValues(FilterId).includes(Number(data) as FilterId)) return;
+        return setActiveFilterId(Number(data));
       default:
         // eslint-disable-next-line no-console
         console.error('등록된 핸들러가 없습니다.');


### PR DESCRIPTION
## Motivation
close #108 
- 플러터 통신 구조를 사용하여 온보딩 필터를 요청하고 응답받아 set recoil atom 하는 로직을 했습니다.

<br>

## Key Changes

- getOnboardingFilter 요청 Filter/index.ts onMount에 요청
- setOnboardingFilter 처리: Filter enum에 있는지 체크, 있다면 activeFilterIdAtom에 값 할당

### 스크린샷
~~플러터와 연동 후 추가 예정~~
![Jun-15-2023 21-20-33](https://github.com/Hipspot/hipspot-web/assets/69510981/7fa03cb1-a820-4b18-8f3b-c31b7f353f25)

<br>

## To Reviewers

- ~~(23.06.15) 플러터와 연동해서 확인 후 머지하겠습니다.~~ 연동완료
